### PR TITLE
add biocViews to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,6 +38,7 @@ Imports:
     SymSim
 Depends:
     R (>= 3.6.0)
+biocViews:
 Remotes:
     YosefLab/SymSim
 RoxygenNote: 7.1.1


### PR DESCRIPTION
In my hands, install of `mrtree` fails because the `ggtree` package fails to auto-install. I believe this is because the `DESCRIPTION` file doesnt provide an indication that `ggtree` could be found in bioconductor. As far as I know, the easiest way around this is to add an empty section to the `DESCRIPTION` file containing `biocViews:` (described in detail [here](https://bioinformatics.stackexchange.com/questions/3365/r-package-development-how-does-one-automatically-install-bioconductor-packages)).

Normally I wouldnt ask for a pull request for something so minor but we're developing a package that depends on `mrtree` so having this fixed in `mrtree` would prevent users of our package from having to manually install `ggtree` after receiving the installation failure message.

I've tested this on my end and this let auto install proceed without error.

Would it be possible to merge this?